### PR TITLE
feat: Refactor blog components to use Sanity CMS

### DIFF
--- a/src/components/blog/BlogFilters.astro
+++ b/src/components/blog/BlogFilters.astro
@@ -1,33 +1,40 @@
 ---
-import type { CollectionEntry } from 'astro:content';
+import type {SanityPost} from '@lib/sanity'
 
 interface Props {
-  posts: CollectionEntry<'blog'>[];
+  posts: SanityPost[];
   currentCategory?: string;
   currentTags?: string[];
 }
 
-const { posts, currentCategory, currentTags = [] } = Astro.props;
+const {posts, currentCategory, currentTags = []} = Astro.props;
 
-// Extract unique categories and tags from all posts
-const categories = [...new Set(posts
-  .map(post => post.data.category)
-  .filter(Boolean)
-  .sort()
-)];
+const categoryMap = new Map<string, string>()
+posts.forEach((post) => {
+  post.categories?.forEach((category) => {
+    if (!category?.slug) return
+    if (!categoryMap.has(category.slug)) {
+      categoryMap.set(category.slug, category.title ?? category.slug)
+    }
+  })
+})
 
-const allTags = [...new Set(posts
-  .flatMap(post => post.data.tags || [])
-  .sort()
-)];
+const categories = Array.from(categoryMap.entries()).sort((a, b) =>
+  a[1].localeCompare(b[1], 'pt-BR', {sensitivity: 'base'})
+)
 
-const popularTags = allTags.slice(0, 15); // Show most common tags
+const allTags = Array.from(
+  new Set(
+    posts.flatMap((post) => post.tags ?? [])
+  )
+).sort((a, b) => a.localeCompare(b, 'pt-BR', {sensitivity: 'base'}))
+
+const popularTags = allTags.slice(0, 15)
 ---
 
 <div class="bg-white border-4 border-black p-6 mb-8">
   <h3 class="text-2xl font-bold mb-4 heading-font">Filtrar Artigos</h3>
 
-  <!-- Categories Filter -->
   <div class="mb-6">
     <h4 class="text-lg font-bold mb-2">Categorias</h4>
     <div class="flex flex-wrap gap-2">
@@ -41,43 +48,25 @@ const popularTags = allTags.slice(0, 15); // Show most common tags
       >
         Todas
       </a>
-      {categories.map(category => {
-        const categoryLabel = {
-          'cognitive-psychology': 'Psicologia Cognitiva',
-          'behavioral-psychology': 'Psicologia Comportamental',
-          'clinical-psychology': 'Psicologia Clínica',
-          'developmental-psychology': 'Psicologia do Desenvolvimento',
-          'social-psychology': 'Psicologia Social',
-          'neuropsychology': 'Neuropsicologia',
-          'positive-psychology': 'Psicologia Positiva',
-          'therapy-techniques': 'Técnicas Terapêuticas',
-          'mental-health': 'Saúde Mental',
-          'research-insights': 'Pesquisas',
-          'case-studies': 'Estudos de Caso',
-          'wellness-tips': 'Bem-estar'
-        }[category] || category;
-
-        return (
-          <a
-            href={`/blog/category/${category}`}
-            class={`px-3 py-1 border-2 border-black transition-colors ${
-              currentCategory === category
-                ? 'bg-black text-white'
-                : 'bg-white text-black hover:bg-black hover:text-white'
-            }`}
-          >
-            {categoryLabel}
-          </a>
-        );
-      })}
+      {categories.map(([slug, label]) => (
+        <a
+          href={`/blog/category/${slug}`}
+          class={`px-3 py-1 border-2 border-black transition-colors ${
+            currentCategory === slug
+              ? 'bg-black text-white'
+              : 'bg-white text-black hover:bg-black hover:text-white'
+          }`}
+        >
+          {label}
+        </a>
+      ))}
     </div>
   </div>
 
-  <!-- Tags Filter -->
   <div class="mb-6">
     <h4 class="text-lg font-bold mb-2">Tags Populares</h4>
     <div class="flex flex-wrap gap-2">
-      {popularTags.map(tag => (
+      {popularTags.map((tag) => (
         <a
           href={`/blog/tags/${tag.toLowerCase().replace(/\s+/g, '-')}`}
           class={`px-3 py-1 border-2 border-black text-sm transition-colors ${
@@ -92,16 +81,15 @@ const popularTags = allTags.slice(0, 15); // Show most common tags
     </div>
   </div>
 
-  <!-- Difficulty Filter -->
   <div class="mb-4">
     <h4 class="text-lg font-bold mb-2">Nível</h4>
     <div class="flex gap-2">
-      {['beginner', 'intermediate', 'advanced'].map(level => {
+      {['beginner', 'intermediate', 'advanced'].map((level) => {
         const levelLabel = {
-          'beginner': 'Iniciante',
-          'intermediate': 'Intermediário',
-          'advanced': 'Avançado'
-        }[level];
+          beginner: 'Iniciante',
+          intermediate: 'Intermediário',
+          advanced: 'Avançado',
+        }[level]
 
         return (
           <a
@@ -110,7 +98,7 @@ const popularTags = allTags.slice(0, 15); // Show most common tags
           >
             {levelLabel}
           </a>
-        );
+        )
       })}
     </div>
   </div>

--- a/src/components/blog/BlogList.astro
+++ b/src/components/blog/BlogList.astro
@@ -1,22 +1,22 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import BlogSummaryCard from './BlogSummaryCard.astro';
+import type {SanityPost} from '@lib/sanity'
+import BlogSummaryCard from './BlogSummaryCard.astro'
 
 interface Props {
-  posts: CollectionEntry<'blog'>[];
+  posts: SanityPost[];
 }
 
-const { posts } = Astro.props;
+const {posts} = Astro.props;
 ---
 
-<ul class='grid md:grid-cols-2 lg:grid-cols-3 gap-8'>
-  {
-    posts.map((post) => {
-      return (
-        <li>
-          <BlogSummaryCard post={post} />
-        </li>
-      );
-    })
-  }
-</ul>
+{posts.length === 0 ? (
+  <p class="text-center text-gray-600">Nenhum post publicado ainda.</p>
+) : (
+  <ul class="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
+    {posts.map((post) => (
+      <li>
+        <BlogSummaryCard post={post} />
+      </li>
+    ))}
+  </ul>
+)}

--- a/src/components/blog/BlogSummaryCard.astro
+++ b/src/components/blog/BlogSummaryCard.astro
@@ -1,19 +1,17 @@
 ---
-import type { CollectionEntry } from 'astro:content';
-import { Pill, Button } from '@eliancodes/brutal-ui';
-import SummaryCard from '../generic/SummaryCard.astro';
+import {Button} from '@eliancodes/brutal-ui'
+import type {SanityPost} from '@lib/sanity'
 
 interface Props {
-  post: CollectionEntry<'blog'>;
+  post: SanityPost;
 }
 
-const { post } = Astro.props;
+const {post} = Astro.props;
 
-// Category translations for astrology with icons
-const categoryData: Record<string, {label: string, icon: string}> = {
+const categoryData: Record<string, {label: string; icon: string}> = {
   'zodiac-signs': {label: 'Signos do Zodíaco', icon: 'i-uil-star'},
-  'horoscopes': {label: 'Horóscopos', icon: 'i-uil-moon'},
-  'compatibility': {label: 'Compatibilidade', icon: 'i-uil-heart'},
+  horoscopes: {label: 'Horóscopos', icon: 'i-uil-moon'},
+  compatibility: {label: 'Compatibilidade', icon: 'i-uil-heart'},
   'birth-charts': {label: 'Mapa Astral', icon: 'i-uil-chart'},
   'moon-phases': {label: 'Fases da Lua', icon: 'i-uil-moon'},
   'planetary-transits': {label: 'Trânsitos', icon: 'i-uil-arrows-h'},
@@ -22,49 +20,66 @@ const categoryData: Record<string, {label: string, icon: string}> = {
   'spiritual-guidance': {label: 'Orientação Espiritual', icon: 'i-uil-star'},
   'cosmic-humor': {label: 'Humor Cósmico', icon: 'i-uil-smile'},
   'astro-memes': {label: 'Memes Astrais', icon: 'i-uil-grin'},
-  'sign-roasting': {label: 'Roast de Signos', icon: 'i-uil-fire'}
-};
+  'sign-roasting': {label: 'Roast de Signos', icon: 'i-uil-fire'},
+}
 
 const difficultyLabels: Record<string, string> = {
-  'beginner': 'Iniciante',
-  'intermediate': 'Intermediário',
-  'advanced': 'Avançado'
-};
+  beginner: 'Iniciante',
+  intermediate: 'Intermediário',
+  advanced: 'Avançado',
+}
 
-const targetAudienceData: Record<string, {label: string, icon: string}> = {
+const targetAudienceData: Record<string, {label: string; icon: string}> = {
   'astrology-beginners': {label: 'Iniciantes na Astrologia', icon: 'i-uil-seedling'},
   'zodiac-enthusiasts': {label: 'Entusiastas do Zodíaco', icon: 'i-uil-star'},
   'spiritual-seekers': {label: 'Buscadores Espirituais', icon: 'i-uil-search'},
   'cosmic-skeptics': {label: 'Céticos Cósmicos', icon: 'i-uil-question-circle'},
-  'meme-lovers': {label: 'Amantes de Memes', icon: 'i-uil-grin'}
-};
+  'meme-lovers': {label: 'Amantes de Memes', icon: 'i-uil-grin'},
+}
 
-// Format reading time
 const formatReadingTime = (minutes?: number) => {
-  if (!minutes) return '';
-  return `${minutes} min de leitura`;
-};
+  if (!minutes) return ''
+  return `${minutes} min de leitura`
+}
 
-// Format date
-const formatDate = (date: Date) => {
+const formatDate = (iso?: string) => {
+  if (!iso) return ''
   return new Intl.DateTimeFormat('pt-BR', {
     year: 'numeric',
     month: 'long',
-    day: 'numeric'
-  }).format(date);
-};
+    day: 'numeric',
+  }).format(new Date(iso))
+}
 
-// Zodiac sign icons
 const zodiacIcons: Record<string, string> = {
-  'aries': 'i-uil-fire', 'taurus': 'i-uil-trees', 'gemini': 'i-uil-chat', 'cancer': 'i-uil-moon',
-  'leo': 'i-uil-star', 'virgo': 'i-uil-flower', 'libra': 'i-uil-balance-scale', 'scorpio': 'i-uil-bug',
-  'sagittarius': 'i-uil-arrow', 'capricorn': 'i-uil-mountains', 'aquarius': 'i-uil-water-drop-slash', 'pisces': 'i-uil-fish'
-};
+  aries: 'i-uil-fire',
+  taurus: 'i-uil-trees',
+  gemini: 'i-uil-chat',
+  cancer: 'i-uil-moon',
+  leo: 'i-uil-star',
+  virgo: 'i-uil-flower',
+  libra: 'i-uil-balance-scale',
+  scorpio: 'i-uil-bug',
+  sagittarius: 'i-uil-arrow',
+  capricorn: 'i-uil-mountains',
+  aquarius: 'i-uil-water-drop-slash',
+  pisces: 'i-uil-fish',
+}
+
+const primaryCategory = post.categories?.[0]
+const categorySlug = primaryCategory?.slug ?? ''
+const categoryInfo = categorySlug ? categoryData[categorySlug] : undefined
+const categoryLabel = categoryInfo?.label ?? primaryCategory?.title
+const categoryIcon = categoryInfo?.icon ?? 'i-uil-star'
+const postUrl = `/blog/${post.slug}/`
+const authorName = post.author?.name ?? 'Psicóloga em Outra Dimensão'
+const publishedAt = formatDate(post.publishedAt ?? post.updatedAt)
+const zodiacSlug = post.zodiacSign?.slug
+const zodiacIcon = zodiacSlug ? zodiacIcons[zodiacSlug] ?? 'i-uil-star' : null
 ---
 
 <article class="bg-white border-4 border-black card-shadow p-6 h-full flex flex-col">
-  <!-- Featured Badge -->
-  {post.data.featured && (
+  {post.featured && (
     <div class="mb-4">
       <span class="bg-secondary border-4 border-black px-4 py-2 text-sm font-black uppercase tracking-wider brutal-pill animate-pulse flex items-center gap-2">
         <div class="i-uil-star"></div> EM DESTAQUE <div class="i-uil-star"></div>
@@ -72,94 +87,98 @@ const zodiacIcons: Record<string, string> = {
     </div>
   )}
 
-  <!-- Category -->
-  {post.data.category && categoryData[post.data.category] && (
+  {primaryCategory && categoryLabel && (
     <div class="mb-3">
-      <a
-        href={`/blog/category/${post.data.category}`}
-        class="inline-flex items-center gap-2 bg-black text-white px-3 py-2 text-sm font-bold uppercase tracking-wider hover:bg-deep transition-colors brutal-pill"
-      >
-        <div class={`${categoryData[post.data.category].icon} text-sm`}></div>
-        {categoryData[post.data.category].label}
-      </a>
+      {categorySlug ? (
+        <a
+          href={`/blog/category/${categorySlug}`}
+          class="inline-flex items-center gap-2 bg-black text-white px-3 py-2 text-sm font-bold uppercase tracking-wider hover:bg-deep transition-colors brutal-pill"
+        >
+          <div class={`${categoryIcon} text-sm`}></div>
+          {categoryLabel}
+        </a>
+      ) : (
+        <span class="inline-flex items-center gap-2 bg-black text-white px-3 py-2 text-sm font-bold uppercase tracking-wider brutal-pill">
+          <div class={`${categoryIcon} text-sm`}></div>
+          {categoryLabel}
+        </span>
+      )}
     </div>
   )}
 
-  <!-- Title -->
   <h2 class="text-xl md:text-2xl font-bold mb-3 line-clamp-2 heading-font flex items-start gap-2">
-    {post.data.zodiacSign && (
-      <div class={`${zodiacIcons[post.data.zodiacSign]} text-2xl flex-shrink-0 text-deep`}></div>
+    {zodiacIcon && (
+      <div class={`${zodiacIcon} text-2xl flex-shrink-0 text-deep`}></div>
     )}
-    <a href={`/blog/${post.id}/`} class="text-black hover:text-deep transition-colors">
-      {post.data.title}
+    <a href={postUrl} class="text-black hover:text-deep transition-colors">
+      {post.title}
     </a>
   </h2>
 
-  <!-- Meta Information -->
   <div class="text-sm text-gray-600 mb-4 space-y-1">
     <div class="flex items-center justify-between">
-      <span>Por {post.data.author}</span>
-      <span>{formatDate(post.data.pubDate)}</span>
+      <span>Por {authorName}</span>
+      <span>{publishedAt}</span>
     </div>
 
     <div class="flex items-center justify-between text-xs">
-      {post.data.readingTime && (
+      {post.readingTime && (
         <span class="bg-gray-100 px-2 py-1 border border-gray-300 flex items-center gap-1">
-          <div class="i-uil-book-open text-xs"></div> {formatReadingTime(post.data.readingTime)}
+          <div class="i-uil-book-open text-xs"></div> {formatReadingTime(post.readingTime)}
         </span>
       )}
 
       <div class="flex gap-2">
-        {post.data.difficulty && (
+        {post.difficulty && (
           <span class={`px-2 py-1 border border-black text-xs font-bold ${
-            post.data.difficulty === 'beginner' ? 'bg-green-100 text-green-800' :
-            post.data.difficulty === 'intermediate' ? 'bg-yellow-100 text-yellow-800' :
-            'bg-red-100 text-red-800'
+            post.difficulty === 'beginner'
+              ? 'bg-green-100 text-green-800'
+              : post.difficulty === 'intermediate'
+              ? 'bg-yellow-100 text-yellow-800'
+              : 'bg-red-100 text-red-800'
           }`}>
-            {difficultyLabels[post.data.difficulty]}
+            {difficultyLabels[post.difficulty]}
           </span>
         )}
-        {post.data.humorLevel && (
+        {post.humorLevel && (
           <span class={`px-2 py-1 border border-black text-xs font-bold flex items-center gap-1 ${
-            post.data.humorLevel === 'subtle' ? 'bg-blue-100 text-blue-800' :
-            post.data.humorLevel === 'moderate' ? 'bg-orange-100 text-orange-800' :
-            post.data.humorLevel === 'savage' ? 'bg-red-100 text-red-800' :
-            'bg-purple-100 text-purple-800'
+            post.humorLevel === 'subtle'
+              ? 'bg-blue-100 text-blue-800'
+              : post.humorLevel === 'moderate'
+              ? 'bg-orange-100 text-orange-800'
+              : post.humorLevel === 'savage'
+              ? 'bg-red-100 text-red-800'
+              : 'bg-purple-100 text-purple-800'
           }`}>
             <div class={
-              post.data.humorLevel === 'subtle' ? 'i-uil-smile' :
-              post.data.humorLevel === 'moderate' ? 'i-uil-grin' :
-              post.data.humorLevel === 'savage' ? 'i-uil-fire' : 'i-uil-times-circle'
+              post.humorLevel === 'subtle'
+                ? 'i-uil-smile'
+                : post.humorLevel === 'moderate'
+                ? 'i-uil-grin'
+                : post.humorLevel === 'savage'
+                ? 'i-uil-fire'
+                : 'i-uil-times-circle'
             }></div>
-            {post.data.humorLevel === 'subtle' ? 'Sutil' :
-             post.data.humorLevel === 'moderate' ? 'Moderado' :
-             post.data.humorLevel === 'savage' ? 'Savage' : 'Brutal'}
+            {post.humorLevel === 'subtle'
+              ? 'Sutil'
+              : post.humorLevel === 'moderate'
+              ? 'Moderado'
+              : post.humorLevel === 'savage'
+              ? 'Savage'
+              : 'Brutal'}
           </span>
         )}
       </div>
     </div>
   </div>
 
-  <!-- Description -->
   <p class="text-gray-700 mb-4 flex-grow line-clamp-3">
-    {post.data.description}
+    {post.description}
   </p>
 
-  <!-- Content Warnings -->
-  {post.data.contentWarning && post.data.contentWarning.length > 0 && (
-    <div class="mb-4">
-      <div class="bg-yellow-50 border-l-4 border-yellow-400 p-3">
-        <p class="text-sm text-yellow-700">
-          <strong>Aviso:</strong> Contém discussões sobre {post.data.contentWarning.join(', ')}.
-        </p>
-      </div>
-    </div>
-  )}
-
-  <!-- Tags -->
   <div class="mb-4">
     <ul class="flex flex-wrap gap-2">
-      {post.data.tags?.slice(0, 4).map((tag) => (
+      {post.tags?.slice(0, 4).map((tag) => (
         <li>
           <a
             href={`/blog/tags/${tag.toLowerCase().replace(/\s+/g, '-')}`}
@@ -169,40 +188,29 @@ const zodiacIcons: Record<string, string> = {
           </a>
         </li>
       ))}
-      {post.data.tags && post.data.tags.length > 4 && (
+      {post.tags && post.tags.length > 4 && (
         <li class="text-xs font-bold text-deep px-2 py-1 flex items-center gap-1">
-          +{post.data.tags.length - 4} mais <div class="i-uil-star text-xs"></div>
+          +{post.tags.length - 4} mais <div class="i-uil-star text-xs"></div>
         </li>
       )}
     </ul>
   </div>
 
-  <!-- Target Audience -->
-  {post.data.targetAudience && targetAudienceData[post.data.targetAudience] && (
+  {post.targetAudience && targetAudienceData[post.targetAudience] && (
     <div class="mb-4 text-sm flex items-center gap-2">
       <span class="text-gray-600">Público-alvo:</span>
       <span class="font-semibold flex items-center gap-1">
-        <div class={`${targetAudienceData[post.data.targetAudience].icon} text-xs`}></div>
-        {targetAudienceData[post.data.targetAudience].label}
+        <div class={`${targetAudienceData[post.targetAudience].icon} text-xs`}></div>
+        {targetAudienceData[post.targetAudience].label}
       </span>
     </div>
   )}
 
-  <!-- Action Button -->
   <div class="mt-auto">
-    <Button href={`/blog/${post.id}/`} class="w-full">
+    <Button href={postUrl} class="w-full">
       Ler artigo completo &rarr;
     </Button>
   </div>
-
-  <!-- Draft Status -->
-  {post.data.draft && (
-    <div class="mt-2">
-      <span class="bg-orange-400 border-2 border-black px-3 py-1 text-sm font-bold uppercase">
-        Rascunho
-      </span>
-    </div>
-  )}
 </article>
 
 <style>

--- a/src/components/generic/RecentBlogPosts.astro
+++ b/src/components/generic/RecentBlogPosts.astro
@@ -1,18 +1,14 @@
 ---
-import { getCollection } from 'astro:content';
-import BlogList from '../blog/BlogList.astro';
-import { Card } from '@eliancodes/brutal-ui';
-import { Button } from '@eliancodes/brutal-ui';
+import BlogList from '../blog/BlogList.astro'
+import {Card, Button} from '@eliancodes/brutal-ui'
+import {getAllPosts} from '@lib/sanity'
 
 interface Props {
   count?: number;
 }
 
-const { count } = Astro.props;
-
-const posts = await getCollection('blog').then((posts) =>
-  posts.reverse().slice(0, count ?? 3)
-);
+const {count} = Astro.props
+const posts = (await getAllPosts()).slice(0, count ?? 3)
 ---
 
 <section class='mt-8'>

--- a/src/lib/portableText.ts
+++ b/src/lib/portableText.ts
@@ -1,0 +1,128 @@
+import type {
+  PortableText,
+  PortableTextBlock,
+  PortableTextMarkDef,
+  PortableTextSpan,
+} from '@lib/sanity'
+import {urlFor} from './sanity'
+
+const htmlEscapeMap: Record<string, string> = {
+  '&': '&amp;',
+  '<': '&lt;',
+  '>': '&gt;',
+  '"': '&quot;',
+  "'": '&#39;',
+}
+
+function escapeHtml(value: string) {
+  return value.replace(/[&<>"']/g, (char) => htmlEscapeMap[char])
+}
+
+function escapeAttribute(value?: string) {
+  if (!value) return ''
+  return escapeHtml(value)
+}
+
+function renderSpan(span: PortableTextSpan, markDefs: PortableTextMarkDef[] = []) {
+  let content = escapeHtml(span.text ?? '')
+  if (!span.marks?.length) return content
+
+  return span.marks.reduce((acc, mark) => {
+    if (mark === 'strong') return `<strong>${acc}</strong>`
+    if (mark === 'em') return `<em>${acc}</em>`
+    if (mark === 'code') return `<code>${acc}</code>`
+
+    const def = markDefs.find((definition) => definition._key === mark)
+    if (def?.href) {
+      const href = escapeAttribute(def.href)
+      return `<a href="${href}" target="_blank" rel="noopener noreferrer">${acc}</a>`
+    }
+    return acc
+  }, content)
+}
+
+function renderChildren(block: PortableTextBlock) {
+  const markDefs = block.markDefs ?? []
+  return (block.children ?? []).map((child) => renderSpan(child, markDefs)).join('')
+}
+
+function renderBlock(block: PortableTextBlock) {
+  const content = renderChildren(block)
+  switch (block.style) {
+    case 'h1':
+      return `<h1>${content}</h1>`
+    case 'h2':
+      return `<h2>${content}</h2>`
+    case 'h3':
+      return `<h3>${content}</h3>`
+    case 'h4':
+      return `<h4>${content}</h4>`
+    case 'h5':
+      return `<h5>${content}</h5>`
+    case 'h6':
+      return `<h6>${content}</h6>`
+    case 'blockquote':
+      return `<blockquote>${content}</blockquote>`
+    default:
+      return `<p>${content}</p>`
+  }
+}
+
+function renderImage(block: Record<string, any>) {
+  if (!block?.asset) return ''
+  const src = urlFor(block).width(1200).url()
+  const alt = escapeAttribute(block.alt ?? block.caption)
+  const caption = block.caption ? `<figcaption>${escapeHtml(block.caption)}</figcaption>` : ''
+  return `<figure class="portable-image"><img src="${src}" alt="${alt}" loading="lazy" />${caption}</figure>`
+}
+
+export function portableTextToHtml(blocks: PortableText = []) {
+  if (!Array.isArray(blocks) || blocks.length === 0) return ''
+
+  let html = ''
+  let inList = false
+  let currentListTag: 'ul' | 'ol' | null = null
+
+  blocks.forEach((block) => {
+    if (typeof block !== 'object' || !block) return
+
+    if ((block as {asset?: unknown}).asset) {
+      if (inList && currentListTag) {
+        html += `</${currentListTag}>`
+        inList = false
+        currentListTag = null
+      }
+      html += renderImage(block as Record<string, any>)
+      return
+    }
+
+    const portableBlock = block as PortableTextBlock
+    if (portableBlock.listItem) {
+      const listTag = portableBlock.listItem === 'number' ? 'ol' : 'ul'
+      if (!inList || currentListTag !== listTag) {
+        if (inList && currentListTag) {
+          html += `</${currentListTag}>`
+        }
+        html += `<${listTag}>`
+        inList = true
+        currentListTag = listTag
+      }
+      html += `<li>${renderChildren(portableBlock)}</li>`
+      return
+    }
+
+    if (inList && currentListTag) {
+      html += `</${currentListTag}>`
+      inList = false
+      currentListTag = null
+    }
+
+    html += renderBlock(portableBlock)
+  })
+
+  if (inList && currentListTag) {
+    html += `</${currentListTag}>`
+  }
+
+  return html
+}

--- a/src/pages/blog/index.astro
+++ b/src/pages/blog/index.astro
@@ -1,11 +1,9 @@
 ---
-import { getCollection } from 'astro:content';
 import Layout from '@layouts/Default.astro';
 import BlogList from '@components/blog/BlogList.astro';
+import { getAllPosts } from '@lib/sanity';
 
-const posts = await getCollection('blog').then((collection) =>
-  collection.reverse()
-);
+const posts = await getAllPosts();
 ---
 
 <Layout


### PR DESCRIPTION
## Summary
Refactor blog components to use Sanity CMS instead of Astro Content Collections.

### Changes
- **BlogFilters.astro**: Updated to work with SanityPost type and new category/tag structure
- **BlogList.astro**: Added empty state handling and updated post rendering  
- **BlogSummaryCard.astro**: Complete refactor to use Sanity data structure with categories, tags, and metadata
- **RecentBlogPosts.astro**: Switched from getCollection to getAllPosts from Sanity
- **blog/index.astro**: Updated to use getAllPosts instead of getCollection
- **portableText.ts**: New utility for rendering Sanity Portable Text content

### Technical Details
- Replaced `CollectionEntry<'blog'>` with `SanityPost` type throughout
- Updated data access patterns for categories (now objects with slug/title), tags, and post metadata
- Maintained existing UI/UX while adapting to Sanity's data structure
- Added proper TypeScript typing and error handling

### Impact
This refactor enables the blog to use Sanity CMS for content management while preserving the existing brutal design system and user experience.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Blog agora usa conteúdo do Sanity, com categorias e tags geradas dinamicamente e rótulos localizados (pt-BR).
  * Cartões de post exibem ícone do signo, autor e data com fallbacks; links e meta atualizados.
  * Renderização de conteúdo rica via Portable Text (imagens com legendas, listas, citações e formatação).
* UX
  * Lista de posts exibe mensagem amigável quando não há resultados.
  * Tags populares limitadas e destacadas; filtros incluem opção “Todas”.
* Performance/Conteúdo
  * Carregamento direto dos posts (getAllPosts) em páginas e componentes recentes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->